### PR TITLE
Computer decommission date now accepts null values

### DIFF
--- a/bangazon/bangazon/api/models/model_computer.py
+++ b/bangazon/bangazon/api/models/model_computer.py
@@ -12,4 +12,4 @@ class Computer(models.Model):
     Author: Zak Spence
     """
     date_purchased = models.DateField()
-    date_decommissioned = models.DateField()
+    date_decommissioned = models.DateField(blank=True, null=True)


### PR DESCRIPTION
## Associated Ticket
[Cannot create computer without decommission date](https://github.com/solanum-tuberosums/bangazonOrientationAPI/issues/39)

## Description 
Computer Decommission Date field now allows NULL values as placeholders.

## Migrations
- [x] Yes

<p style="text-align: center;"><center>🥔</center></p>
